### PR TITLE
Remove option local-repo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 ### Scan CI Pipeline
 
+This action applies configs in `vulcan.yaml` if it exists in the root of the repo. See `local-config` and `use-local-config` options.
+
+Scans local repository with targets defined in `vulcan.yaml`.
+
 ```yaml
 name: Build
 on:
@@ -14,16 +18,32 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Scan with vulcan-local
+      - name: Scan with vulcan-local using vulcan.yaml config
         uses: adevinta/vulcan-local-action@master
 ```
 
-Scans local repository with default checks:
+Scans local repository path.
 
-- Perform static analysis over the current repository. See  `scan-repo` option.
-- Applies configs in `vulcan.yaml` if it exists in the root of the repo. See `local-config` and `use-local-config` options.
+```yaml
+name: Build
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan path . only, using vulcan.yaml configs if exists.
+        uses: adevinta/vulcan-local-action@master
+        with:
+          scan-paths: .
+```
 
 ### Scan repository AND container images
+
+Scans local repository with default checks:
+
+- Builds the image
+- Performs scanning of repo and image
 
 ```yaml
 name: Build
@@ -42,17 +62,14 @@ jobs:
       - name: Scan with vulcan-local
         uses: adevinta/vulcan-local-action@master
         with:
+          target-paths: .
           target-images: ${{ steps.build.outputs.image }}
           report-severity: MEDIUM
 ```
 
-Scans local repository with default checks:
-
-- Builds the image
-- Performs the same scanning as the previous example.
-- Scans the image for vulnerabilities.
-
 ### Scan private images
+
+Provides credentials to authenticate on a registry.
 
 ```yaml
 name: build
@@ -70,19 +87,4 @@ jobs:
           target-images: docker.io/mysuer/image:tag
           report-severity: MEDIUM
           vars: REGISTRY_DOMAIN=docker.io REGISTRY_USERNAME=mysuer REGISTRY_PASSWORD=${{ secrets.DOCKER_PWD }}
-```
-
-Provides credentials to authenticate on a registry.
-
-### Use vulcan.yaml
-
-Most of the options can be set in `vulcan.yaml`.
-The file is used by default.
-
-Also it can be used to add exclusions for false positives or for other reasons.
-
-```yaml
-reporting:
-  exclusions:
-    - affectedResource: e2fsprogs
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -51,11 +51,6 @@ inputs:
       - MEDIUM
       - LOW
 
-  scan-repo:
-    description: Whether to scan the local repo path
-    type: boolean
-    default: true
-
   target-images:
     description: Space separated list of images to scan
     type: string
@@ -143,7 +138,6 @@ runs:
         LOCAL_CONFIG: ${{ inputs.local-config }}
         USE_LOCAL_CONFIG: ${{ inputs.use-local-config }}
         LOG_LEVEL: ${{ inputs.log-level }}
-        SCAN_REPO: ${{ inputs.scan-repo }}
         TARGET_IMAGES: ${{ inputs.target-images }}
         TARGET_PATHS: ${{ inputs.target-paths }}
         INCLUDE: ${{ inputs.include }}

--- a/run.sh
+++ b/run.sh
@@ -50,10 +50,6 @@ for ELEM in ${VARS}; do
     VL_HIDDEN_ARGS+=("-v" "${ELEM}")
 done
 
-if [ "${SCAN_REPO}" == "true" ]; then
-    VL_ARGS+=("-t" "." "-a" "GitRepository")
-fi
-
 if [ -n "${REPORT_SEVERITY}" ]; then
     VL_ARGS+=("-s" "$REPORT_SEVERITY" )
 fi


### PR DESCRIPTION
Remove `local-repo` option that added `.` as a target and make it explicit by using `target-paths: .`.

This solves the problem when a vulcan.yaml exists with targets defined and local-repo adds `-t . -a GitRepository`
The action generates `vulcan-local -t . -a GitRepository -c vulcan.yaml` and In this situation `vulcan-local` ignores the targets defined in `vulcan.yaml`.

To sum-up

```yaml
     # Scans the targets defined in vulcan.yaml. If no targets, nothing is scanned.
      - uses: adevinta/vulcan-local-action@latest
```

```yaml
     # Scans the target . and ignores the targets in vulcan.yaml (but not the options, exclusions, ..)
      - uses: adevinta/vulcan-local-action@latest
        target-paths: .
```
